### PR TITLE
.env 설정관련 편의 개선

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,7 @@
+# kakao keys (https://developers.kakao.com/console/app/641963)
 KAKAO_REST_KEY=
-KAKAO_REDIRECT_URI=
+KAKAO_JAVASCRIPT_KEY=
+# kakao login redirect
+KAKAO_REDIRECT_URI=https://api.barberforce.shop/kakao/callback
+# backend url (change for localtest..)
+BACKEND_URL=https://api.barberforce.shop

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -65,8 +65,8 @@ export default {
   // Dotenv
   env: {
     kakaoRestKey: process.env.KAKAO_REST_KEY,
-    kakaoRedirectURI: process.env.KAKAO_REDIRECT_URI,
-    backendURL: process.env.BACKEND_URL,
+    kakaoRedirectURI: process.env.KAKAO_REDIRECT_URI || 'https://api.barberforce.shop/kakao/callback',
+    backendURL: process.env.BACKEND_URL || 'https://api.barberforce.shop',
   },
 
   // Nuxt Toast


### PR DESCRIPTION
- .env.example 설명 추가
- .env 없을 경우에도 기본값으로 실서버의 backend url 들어가도록 설정